### PR TITLE
Changed RuleAdapter to only support injection of groups of Facts as L…

### DIFF
--- a/src/test/java/com/deliveredtechnologies/rulebook/runner/RuleAdapterTest.java
+++ b/src/test/java/com/deliveredtechnologies/rulebook/runner/RuleAdapterTest.java
@@ -57,9 +57,9 @@ public class RuleAdapterTest {
 
     Assert.assertEquals("FirstFact", sampleRuleWithResult.getFact1());
     Assert.assertEquals("SecondFact", sampleRuleWithResult.getFact2());
-    Assert.assertEquals(2, sampleRuleWithResult.getStrArray().length);
-    Assert.assertEquals(2, sampleRuleWithResult.get_strList().size());
+    Assert.assertEquals(2, sampleRuleWithResult.getStrList().size());
     Assert.assertEquals(1, sampleRuleWithResult.getValue1());
+    Assert.assertNull(sampleRuleWithResult.getValueSet());
   }
 
   @Test

--- a/src/test/java/com/deliveredtechnologies/rulebook/runner/SampleRuleWithResult.java
+++ b/src/test/java/com/deliveredtechnologies/rulebook/runner/SampleRuleWithResult.java
@@ -9,6 +9,7 @@ import com.deliveredtechnologies.rulebook.annotation.Then;
 import com.deliveredtechnologies.rulebook.annotation.When;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Created by clong on 2/13/17.
@@ -23,13 +24,16 @@ public class SampleRuleWithResult {
   private Fact<String> _fact2;
 
   @Given
-  private String[] _strArray;
-
-  @Given
   private List<String> _strList;
 
   @Given("value1")
   private int _value1;
+
+  @Given
+  private Set<Integer> _valueSet;
+
+  @Given
+  private List<Integer> _valueList;
 
   @Result
   private String _result;
@@ -59,16 +63,20 @@ public class SampleRuleWithResult {
     return _fact2.getValue();
   }
 
-  public String[] getStrArray() {
-    return _strArray;
-  }
-
-  public List<String> get_strList() {
+  public List<String> getStrList() {
     return _strList;
   }
 
   public int getValue1() {
     return _value1;
+  }
+
+  public Set<Integer> getValueSet() {
+    return _valueSet;
+  }
+
+  public List<Integer> getValueList() {
+    return _valueList;
   }
 
   public String getResult() {


### PR DESCRIPTION
…ists.

The reasons this was done were:
  (1) Duplicate Facts may not be preserved; so, using a List can help prevent errors
  (2) Array conversion (coded boxing/unboxing) was a bit messy
  (3) Supporting multiple types of collections was also a bit messy
  (4) List does the job